### PR TITLE
build: add flatpak manifest

### DIFF
--- a/com.pengaru.glimmer.json
+++ b/com.pengaru.glimmer.json
@@ -1,0 +1,30 @@
+{
+    "app-id" : "com.pengaru.glimmer",
+    "runtime" : "org.gnome.Platform",
+    "runtime-version" : "3.38",
+    "sdk" : "org.gnome.Sdk",
+    "command" : "glimmer",
+    "finish-args" : [
+        "--device=dri",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
+    ],
+    "cleanup" : [
+        "*.la",
+        "*.a"
+    ],
+    "modules" : [
+        {
+            "name" : "glimmer",
+            "buildsystem" : "autotools",
+            "builddir" : false,
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/vcaputo/glimmer.git"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows Glimmer to be built against a known runtime from applications
like Builder without installing dependencies on the host. This is useful
for systems with an immutable base OS (like Silverblue) or situations
where you want a predictable development environment.

Also, this could be included in Flathub.org.